### PR TITLE
2 packages from paurkedal/episql at 0.11.1

### DIFF
--- a/packages/caqti-persist/caqti-persist.0.11.1/opam
+++ b/packages/caqti-persist/caqti-persist.0.11.1/opam
@@ -1,0 +1,35 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/episql/"
+bug-reports: "https://github.com/paurkedal/episql/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "caqti" {>= "0.8.1"}
+  "caqti-dynload" {with-test}
+  "caqti-lwt" {>= "0.8.1"}
+  "caqti-type-calendar" {>= "0.8.1"}
+  "extunix"
+  "lwt"
+  "ppx_deriving"
+  "prime"
+  "react"
+]
+conflicts: [
+  "episql" {< "0.9.0"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/episql.git"
+url {
+  src:
+    "https://github.com/paurkedal/episql/releases/download/v0.11.1/episql-v0.11.1.tbz"
+  checksum: [
+    "md5=86b963c71df27c5a76c8688c983592d0"
+    "sha512=961a89cc2b80892bc1a0ea5a1b17c6f6955e895110b24e19e2ccddabec4a5f08fff305a94ae4b1aa6e06aa59428905a38eef404ffed0a6eff7ffa78f0335787d"
+  ]
+}

--- a/packages/episql/episql.0.11.1/opam
+++ b/packages/episql/episql.0.11.1/opam
@@ -1,0 +1,28 @@
+opam-version: "2.0"
+maintainer: "Petter A. Urkedal <paurkedal@gmail.com>"
+authors: "Petter A. Urkedal <paurkedal@gmail.com>"
+license: "LGPL-3 with OCaml linking exception"
+homepage: "https://github.com/paurkedal/episql/"
+bug-reports: "https://github.com/paurkedal/episql/issues"
+depends: [
+  "ocaml"
+  "dune" {build}
+  "lwt"
+  "ppx_compose"
+  "prime"
+  "re"
+  "xmlm"
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/paurkedal/episql.git"
+url {
+  src:
+    "https://github.com/paurkedal/episql/releases/download/v0.11.1/episql-v0.11.1.tbz"
+  checksum: [
+    "md5=86b963c71df27c5a76c8688c983592d0"
+    "sha512=961a89cc2b80892bc1a0ea5a1b17c6f6955e895110b24e19e2ccddabec4a5f08fff305a94ae4b1aa6e06aa59428905a38eef404ffed0a6eff7ffa78f0335787d"
+  ]
+}


### PR DESCRIPTION
This pull-request concerns:
-`caqti-persist.0.11.1`
-`episql.0.11.1`



---
* Homepage: https://github.com/paurkedal/episql/
* Source repo: git+https://github.com/paurkedal/episql.git
* Bug tracker: https://github.com/paurkedal/episql/issues

---
:camel: Pull-request generated by opam-publish v2.0.0